### PR TITLE
Allow attachments from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,14 @@ The following field are optional:
     provide your own HTML.
 
 - `attachments[]`: Attachments to include in the email. A maximum of 5
-  files can be attached. This can only be used when using
+  files can be attached. You can upload files directly when using
   `multipart/form-data` content type. The files should be sent as a
   list of files with the key `attachments[]`.
+
+  You can also send already encoded files via JSON.
+  An attachment sent via JSON needs the keys `originalname`,
+  `buffer` (the file contents), and `mimetype`. You can also
+  supply the `encoding` parameter.
 
 An example of a valid JSON request:
 
@@ -70,7 +75,15 @@ An example of a valid JSON request:
       "address": "ordf@datasektionen.se"
     }
   ],
-  "bcc": ["very@secret.com"]
+  "bcc": ["very@secret.com"],
+  "attachments[]": [
+    {
+      "originalname": "file.txt",
+      "buffer": "Hello World!"
+      "mimetype": "text/plain",
+      "encoding": "utf8"
+    }
+  ]
 }
 ```
 

--- a/api.js
+++ b/api.js
@@ -105,10 +105,11 @@ const sendMail = (req, res) => {
         to: req.body.to, // list of receivers
         cc: req.body.cc || [], // list of cc
         bcc: req.body.bcc || [], // list of bcc
-        attachments: (req.files || []).map((f) => ({
+        attachments: (req.files || req.body["attachements[]"] || []).map((f) => ({
           filename: f.originalname,
           content: f.buffer,
           contentType: f.mimetype,
+          encoding: f.encoding || "utf8" // only applies when buffer is a string
         })),
       },
       template: template,

--- a/api.js
+++ b/api.js
@@ -105,7 +105,7 @@ const sendMail = (req, res) => {
         to: req.body.to, // list of receivers
         cc: req.body.cc || [], // list of cc
         bcc: req.body.bcc || [], // list of bcc
-        attachments: (req.files || req.body["attachements[]"] || []).map((f) => ({
+        attachments: (req.files || req.body["attachments[]"] || []).map((f) => ({
           filename: f.originalname,
           content: f.buffer,
           contentType: f.mimetype,


### PR DESCRIPTION
I want to attach files to my emails but I don't want to use multipart/form-data. Should be backwards compatible.